### PR TITLE
chore(ci): upstream-2022-10-20-sync

### DIFF
--- a/scripts/sync-for-pull-request.sh
+++ b/scripts/sync-for-pull-request.sh
@@ -8,6 +8,6 @@
 ./scripts/sync-sub-modules.py \
    --synchronize \
    --force \
-   --gnbsim golint-oct-fixes \
+   --gnbsim upstream-2022-10-20-sync \
    --nas ngap-tester \
    --ngap ngap-tester


### PR DESCRIPTION
Signed-off-by: Raphael Defosseux <raphael.defosseux@openairinterface.org>

## Summary

Synchronizing with upstream repository

## Test Plan

CI to test functionality.

I already know that linter will fail

## Check List
