### PR TITLE
test(oai-cn5g): testing more UEs

### DIFF
--- a/scripts/sync-for-pull-request.sh
+++ b/scripts/sync-for-pull-request.sh
@@ -2,12 +2,12 @@
 # for each sub-module
 # If you want to re-trigger the CI jobs with the same branches
 # But new commits, just add the commit SHA-ONE as comment
-# gnbsim branch: upstream-2022-10-20-sync / fb864d5141f0ceab2513c2071c92de2acf8f14c4
+# gnbsim branch: enable-bypass-traffic-test / 2cfe11cf44980ec15575cbb777585f24ebfde9a4
 # nas branch: N/A
 # ngap branch: N/A
 ./scripts/sync-sub-modules.py \
    --synchronize \
    --force \
-   --gnbsim upstream-2022-10-20-sync \
+   --gnbsim enable-bypass-traffic-test \
    --nas ngap-tester \
    --ngap ngap-tester

--- a/test/omec-gnbsim-config.yaml
+++ b/test/omec-gnbsim-config.yaml
@@ -58,7 +58,7 @@ configuration:
       opc: "63bfa50ee6523365ff14c1f45f88737d"
       key: "0C0A34601D4F07677303652C0462535B"
       sequenceNumber: "16f3b3f70fc2"
-      dnn: "defult"
+      dnn: "default"
       sNssai:
         sst: 222 # Slice/Service Type (uinteger, range: 0~255)
         sd: 00007B # Slice Differentiator (3 bytes hex string, range: 000000~FFFFFF)
@@ -122,8 +122,8 @@ configuration:
       enable: true # Set true to execute the profile, false otherwise.
       gnbName: gnb1 # gNB to be used for this profile
       startImsi: 208950000000125 # First IMSI. Subsequent values will be used if ueCount is more than 1
-      ueCount: 2 # Number of UEs for for which the profile will be executed
-      defaultAs: "192.168.70.134" #default icmp pkt destination
+      ueCount: 5 # Number of UEs for for which the profile will be executed
+      defaultAs: "0.0.0.0" #default icmp pkt destination -- here it is bypassed
       opc: "63bfa50ee6523365ff14c1f45f88737d"
       key: "0C0A34601D4F07677303652C0462535B"
       sequenceNumber: "16f3b3f70fc2"


### PR DESCRIPTION
## Summary

In the `omec-gnbsim`, I've enabled the `bypass` on ICMP traffic test.

First testing w/ 5 subscribed UEs.
Then I will expand the UE subscription list (w/ a `awk` script) but later we need to do that through `UDR`.
Finally full cycle testing on 100s of UEs.

## Test Plan

Let CI do the work.

## Check List

[x] `scripts/sync-for-pull-request.sh` was modified.